### PR TITLE
postgresql: map swaps equally

### DIFF
--- a/swapd/src/internal_server.rs
+++ b/swapd/src/internal_server.rs
@@ -13,7 +13,7 @@ use crate::{
     chain::{ChainClient, ChainRepository, FeeEstimate, FeeEstimator},
     chain_filter::ChainFilterRepository,
     redeem::{RedeemError, RedeemRepository, RedeemService, RedeemServiceError},
-    swap::{GetSwapError, PrivateKeyProvider, SwapRepository},
+    swap::{GetSwapsError, PrivateKeyProvider, SwapRepository},
     wallet::{Wallet, WalletError},
 };
 
@@ -189,7 +189,7 @@ where
                     Ok(swap) => swap,
                     Err(e) => {
                         return Err(match e {
-                            GetSwapError::NotFound => Status::not_found("swap not found"),
+                            GetSwapsError::NotFound => Status::not_found("swap not found"),
                             _ => Status::internal(format!("{:?}", e)),
                         })
                     }
@@ -204,7 +204,7 @@ where
                     Ok(swap) => swap,
                     Err(e) => {
                         return Err(match e {
-                            GetSwapError::NotFound => Status::not_found("swap not found"),
+                            GetSwapsError::NotFound => Status::not_found("swap not found"),
                             _ => Status::internal(format!("{:?}", e)),
                         })
                     }
@@ -217,7 +217,7 @@ where
                     Ok(swap) => swap,
                     Err(e) => {
                         return Err(match e {
-                            GetSwapError::NotFound => Status::not_found("swap not found"),
+                            GetSwapsError::NotFound => Status::not_found("swap not found"),
                             _ => Status::internal(format!("{:?}", e)),
                         })
                     }

--- a/swapd/src/public_server.rs
+++ b/swapd/src/public_server.rs
@@ -23,7 +23,7 @@ use crate::{
 };
 
 use crate::swap::{
-    CreateSwapError, GetSwapError, PrivateKeyProvider, SwapPersistenceError, SwapRepository,
+    CreateSwapError, GetSwapsError, PrivateKeyProvider, SwapPersistenceError, SwapRepository,
     SwapService,
 };
 use swap_api::{
@@ -475,18 +475,18 @@ impl From<SwapPersistenceError> for Status {
     }
 }
 
-impl From<GetSwapError> for Status {
-    fn from(value: GetSwapError) -> Self {
+impl From<GetSwapsError> for Status {
+    fn from(value: GetSwapsError) -> Self {
         match value {
-            GetSwapError::NotFound => {
+            GetSwapsError::NotFound => {
                 trace!("swap not found");
                 Status::not_found("swap not found")
             }
-            GetSwapError::General(e) => {
+            GetSwapsError::General(e) => {
                 error!("failed to get swap: {:?}", e);
                 Status::internal("internal error")
             }
-            GetSwapError::InvalidPreimage => {
+            GetSwapsError::InvalidPreimage => {
                 error!("got invalid preimage");
                 Status::internal("internal error")
             }

--- a/swapd/src/swap/swap_repository.rs
+++ b/swapd/src/swap/swap_repository.rs
@@ -26,15 +26,10 @@ pub enum GetPaidUtxosError {
     General(Box<dyn std::error::Error + Sync + Send>),
 }
 
-#[derive(Debug)]
-pub enum GetSwapError {
-    NotFound,
-    InvalidPreimage,
-    General(Box<dyn std::error::Error + Sync + Send>),
-}
-
 #[derive(Debug, Error)]
 pub enum GetSwapsError {
+    #[error("swap not found")]
+    NotFound,
     #[error("invalid preimage")]
     InvalidPreimage,
     #[error("{0}")]
@@ -77,12 +72,12 @@ pub trait SwapRepository {
         label: &str,
         result: &PaymentResult,
     ) -> Result<(), AddPaymentResultError>;
-    async fn get_swap_by_hash(&self, hash: &sha256::Hash) -> Result<SwapState, GetSwapError>;
-    async fn get_swap_by_address(&self, address: &Address) -> Result<SwapState, GetSwapError>;
+    async fn get_swap_by_hash(&self, hash: &sha256::Hash) -> Result<SwapState, GetSwapsError>;
+    async fn get_swap_by_address(&self, address: &Address) -> Result<SwapState, GetSwapsError>;
     async fn get_swap_by_payment_request(
         &self,
         payment_request: &str,
-    ) -> Result<SwapState, GetSwapError>;
+    ) -> Result<SwapState, GetSwapsError>;
     async fn get_swaps(
         &self,
         addresses: &[Address],


### PR DESCRIPTION
There was a bunch of copied code to map swaps from the database. This commit unifies the swap mapping.

Fixes #18