### PR TITLE
ensure payee and add expected payout height

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,18 +18,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,19 +73,20 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fd03a028ef38ba2276dce7e33fcd6369c158a1bca17946c4b1b701891c1ff7"
+checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arrayvec"
@@ -129,9 +118,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -245,12 +234,6 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
-
-[[package]]
-name = "bech32"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
@@ -262,7 +245,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
  "base58ck",
- "bech32 0.11.0",
+ "bech32",
  "bitcoin-internals",
  "bitcoin-io",
  "bitcoin-units",
@@ -305,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 dependencies = [
  "serde",
 ]
@@ -341,9 +324,9 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.3"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27f657647bcff5394bf56c7317665bbf790a137a50eaaa5c6bfbb9e27a518f2d"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -356,9 +339,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -366,9 +349,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
 dependencies = [
  "anstream",
  "anstyle",
@@ -378,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -457,18 +440,18 @@ checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -567,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -604,6 +587,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -786,24 +775,25 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
-]
 
 [[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
-version = "0.9.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
 ]
 
 [[package]]
@@ -853,11 +843,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -908,9 +898,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -929,9 +919,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.3"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
  "http",
@@ -1180,9 +1170,9 @@ checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1199,9 +1189,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.168"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libm"
@@ -1215,38 +1205,35 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
 
 [[package]]
 name = "lightning-invoice"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
+checksum = "50d6beb3b2957ed6120e7380110aed21001cb7122c30528149fb7d517d9bcbda"
 dependencies = [
- "bech32 0.9.1",
+ "bech32",
  "bitcoin",
  "lightning-types",
 ]
 
 [[package]]
 name = "lightning-types"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
+checksum = "f2cd84d4e71472035903e43caded8ecc123066ce466329ccd5ae537a8d5488c7"
 dependencies = [
- "bech32 0.9.1",
  "bitcoin",
- "hex-conservative",
 ]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
@@ -1266,9 +1253,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "matchers"
@@ -1308,16 +1295,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
@@ -1354,16 +1335,6 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -1425,9 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -1518,12 +1489,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,18 +1515,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1570,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1618,9 +1583,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.25"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
  "syn",
@@ -1628,9 +1593,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1689,9 +1654,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1781,9 +1746,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64",
  "bytes",
@@ -1814,6 +1779,7 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -1865,9 +1831,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags",
  "errno",
@@ -1878,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
 dependencies = [
  "log",
  "once_cell",
@@ -1902,9 +1868,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 
 [[package]]
 name = "rustls-webpki"
@@ -1919,9 +1885,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -1996,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2006,18 +1972,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2026,9 +1992,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "itoa",
  "memchr",
@@ -2152,20 +2118,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sqlformat"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
-dependencies = [
- "nom",
- "unicode_categories",
-]
-
-[[package]]
 name = "sqlx"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93334716a037193fac19df402f8571269c84a00852f6a7066b5d2616dcd64d3e"
+checksum = "4410e73b3c0d8442c5f99b425d7a435b5ee0ae4167b3196771dd3f7a01be745f"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -2176,38 +2132,32 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d8060b456358185f7d50c55d9b5066ad956956fddec42ee2e8567134a8936e"
+checksum = "6a007b6936676aa9ab40207cde35daab0a04b823be8ae004368c0793b96a61e0"
 dependencies = [
- "atoi",
- "byteorder",
  "bytes",
  "crc",
  "crossbeam-queue",
  "either",
  "event-listener",
- "futures-channel",
  "futures-core",
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.2",
  "hashlink",
- "hex",
  "indexmap 2.7.0",
  "log",
  "memchr",
  "native-tls",
  "once_cell",
- "paste",
  "percent-encoding",
  "serde",
  "serde_json",
  "sha2",
  "smallvec",
- "sqlformat",
- "thiserror 1.0.69",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -2216,9 +2166,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cac0692bcc9de3b073e8d747391827297e075c7710ff6276d9f7a1f3d58c6657"
+checksum = "3112e2ad78643fef903618d78cf0aec1cb3134b019730edb039b69eaf531f310"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2229,9 +2179,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1804e8a7c7865599c9c79be146dc8a9fd8cc86935fa641d3ea58e5f0688abaa5"
+checksum = "4e9f90acc5ab146a99bf5061a7eb4976b573f560bc898ef3bf8435448dd5e7ad"
 dependencies = [
  "dotenvy",
  "either",
@@ -2255,9 +2205,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
+checksum = "4560278f0e00ce64938540546f59f590d60beee33fffbd3b9cd47851e5fff233"
 dependencies = [
  "atoi",
  "base64",
@@ -2290,16 +2240,16 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror",
  "tracing",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
+checksum = "c5b98a57f363ed6764d5b3a12bfedf62f07aa16e1856a7ddc2a0bb190a959613"
 dependencies = [
  "atoi",
  "base64",
@@ -2310,7 +2260,6 @@ dependencies = [
  "etcetera",
  "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "hex",
  "hkdf",
@@ -2328,16 +2277,16 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 1.0.69",
+ "thiserror",
  "tracing",
  "whoami",
 ]
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b2cf34a45953bfd3daaf3db0f7a7878ab9b7a6b91b422d24a7a9e4c857b680"
+checksum = "f85ca71d3a5b24e64e1d08dd8fe36c6c95c339a896cc33068148906784620540"
 dependencies = [
  "atoi",
  "flume",
@@ -2418,7 +2367,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "thiserror 2.0.6",
+ "thiserror",
  "tokio",
  "tokio-util",
  "tonic",
@@ -2429,9 +2378,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2481,12 +2430,13 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -2494,38 +2444,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec2a1820ebd077e2b90c4df007bebf344cd394098a13c563957d0afc83ea47"
-dependencies = [
- "thiserror-impl 2.0.6",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65750cab40f4ff1929fb1ba509e9914eb756131cef4210da8d5d700d26f6312"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2554,9 +2484,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -2569,9 +2499,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.42.0"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -2586,9 +2516,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2717,6 +2647,7 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]
@@ -2809,9 +2740,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ab17db44d7388991a428b2ee655ce0c212e862eff1768a455c58f9aad6e7893"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
@@ -2833,12 +2764,6 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
-
-[[package]]
-name = "unicode_categories"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "untrusted"
@@ -2877,9 +2802,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -2916,20 +2841,21 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
@@ -2941,9 +2867,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2954,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2964,9 +2890,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2977,15 +2903,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/itest/tests/helpers.py
+++ b/itest/tests/helpers.py
@@ -59,7 +59,8 @@ def create_swap_no_invoice_extended(user: ClnNode, swapper: SwapdServer):
     h = hashlib.sha256(preimage).digest()
     refund_privkey = PrivateKey()
     refund_pubkey = refund_privkey.get_public_key().to_hex()
-    create_swap_resp = swapper.rpc.create_swap(user, refund_pubkey, h)
+    invoice = user.create_invoice(10000, "fake swap invoice")
+    create_swap_resp = swapper.rpc.create_swap(user, refund_pubkey, h, invoice)
     return (
         create_swap_resp.address,
         preimage.hex(),

--- a/itest/tests/swap_pb2.py
+++ b/itest/tests/swap_pb2.py
@@ -19,7 +19,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\nswap.proto\x12\x04swap"8\n\x11\x43reateSwapRequest\x12\x0c\n\x04hash\x18\x01 \x01(\x0c\x12\x15\n\rrefund_pubkey\x18\x02 \x01(\x0c"z\n\x12\x43reateSwapResponse\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x14\n\x0c\x63laim_pubkey\x18\x02 \x01(\x0c\x12\x13\n\x0block_height\x18\x03 \x01(\r\x12(\n\nparameters\x18\x04 \x01(\x0b\x32\x14.swap.SwapParameters")\n\x0ePaySwapRequest\x12\x17\n\x0fpayment_request\x18\x01 \x01(\t"\x11\n\x0fPaySwapResponse"a\n\x11RefundSwapRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x13\n\x0btransaction\x18\x02 \x01(\x0c\x12\x13\n\x0binput_index\x18\x03 \x01(\r\x12\x11\n\tpub_nonce\x18\x04 \x01(\x0c"B\n\x12RefundSwapResponse\x12\x11\n\tpub_nonce\x18\x01 \x01(\x0c\x12\x19\n\x11partial_signature\x18\x02 \x01(\x0c"z\n\x0eSwapParameters\x12\x11\n\tlock_time\x18\x01 \x01(\r\x12\x1b\n\x13max_swap_amount_sat\x18\x02 \x01(\x04\x12\x1b\n\x13min_swap_amount_sat\x18\x03 \x01(\x04\x12\x1b\n\x13min_utxo_amount_sat\x18\x04 \x01(\x04"\x17\n\x15SwapParametersRequest"B\n\x16SwapParametersResponse\x12(\n\nparameters\x18\x01 \x01(\x0b\x32\x14.swap.SwapParameters2\x98\x02\n\x07Swapper\x12\x41\n\nCreateSwap\x12\x17.swap.CreateSwapRequest\x1a\x18.swap.CreateSwapResponse"\x00\x12\x38\n\x07PaySwap\x12\x14.swap.PaySwapRequest\x1a\x15.swap.PaySwapResponse"\x00\x12\x41\n\nRefundSwap\x12\x17.swap.RefundSwapRequest\x1a\x18.swap.RefundSwapResponse"\x00\x12M\n\x0eSwapParameters\x12\x1b.swap.SwapParametersRequest\x1a\x1c.swap.SwapParametersResponse"\x00\x62\x06proto3'
+    b'\n\nswap.proto\x12\x04swap"I\n\x11\x43reateSwapRequest\x12\x0c\n\x04hash\x18\x01 \x01(\x0c\x12\x15\n\rrefund_pubkey\x18\x02 \x01(\x0c\x12\x0f\n\x07invoice\x18\x03 \x01(\t"z\n\x12\x43reateSwapResponse\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x14\n\x0c\x63laim_pubkey\x18\x02 \x01(\x0c\x12\x13\n\x0block_height\x18\x03 \x01(\r\x12(\n\nparameters\x18\x04 \x01(\x0b\x32\x14.swap.SwapParameters")\n\x0ePaySwapRequest\x12\x17\n\x0fpayment_request\x18\x01 \x01(\t"\x11\n\x0fPaySwapResponse"a\n\x11RefundSwapRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x13\n\x0btransaction\x18\x02 \x01(\x0c\x12\x13\n\x0binput_index\x18\x03 \x01(\r\x12\x11\n\tpub_nonce\x18\x04 \x01(\x0c"B\n\x12RefundSwapResponse\x12\x11\n\tpub_nonce\x18\x01 \x01(\x0c\x12\x19\n\x11partial_signature\x18\x02 \x01(\x0c"z\n\x0eSwapParameters\x12\x11\n\tlock_time\x18\x01 \x01(\r\x12\x1b\n\x13max_swap_amount_sat\x18\x02 \x01(\x04\x12\x1b\n\x13min_swap_amount_sat\x18\x03 \x01(\x04\x12\x1b\n\x13min_utxo_amount_sat\x18\x04 \x01(\x04"\x17\n\x15SwapParametersRequest"B\n\x16SwapParametersResponse\x12(\n\nparameters\x18\x01 \x01(\x0b\x32\x14.swap.SwapParameters2\x98\x02\n\x07Swapper\x12\x41\n\nCreateSwap\x12\x17.swap.CreateSwapRequest\x1a\x18.swap.CreateSwapResponse"\x00\x12\x38\n\x07PaySwap\x12\x14.swap.PaySwapRequest\x1a\x15.swap.PaySwapResponse"\x00\x12\x41\n\nRefundSwap\x12\x17.swap.RefundSwapRequest\x1a\x18.swap.RefundSwapResponse"\x00\x12M\n\x0eSwapParameters\x12\x1b.swap.SwapParametersRequest\x1a\x1c.swap.SwapParametersResponse"\x00\x62\x06proto3'
 )
 
 _globals = globals()
@@ -28,23 +28,23 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, "swap_pb2", _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
     DESCRIPTOR._loaded_options = None
     _globals["_CREATESWAPREQUEST"]._serialized_start = 20
-    _globals["_CREATESWAPREQUEST"]._serialized_end = 76
-    _globals["_CREATESWAPRESPONSE"]._serialized_start = 78
-    _globals["_CREATESWAPRESPONSE"]._serialized_end = 200
-    _globals["_PAYSWAPREQUEST"]._serialized_start = 202
-    _globals["_PAYSWAPREQUEST"]._serialized_end = 243
-    _globals["_PAYSWAPRESPONSE"]._serialized_start = 245
-    _globals["_PAYSWAPRESPONSE"]._serialized_end = 262
-    _globals["_REFUNDSWAPREQUEST"]._serialized_start = 264
-    _globals["_REFUNDSWAPREQUEST"]._serialized_end = 361
-    _globals["_REFUNDSWAPRESPONSE"]._serialized_start = 363
-    _globals["_REFUNDSWAPRESPONSE"]._serialized_end = 429
-    _globals["_SWAPPARAMETERS"]._serialized_start = 431
-    _globals["_SWAPPARAMETERS"]._serialized_end = 553
-    _globals["_SWAPPARAMETERSREQUEST"]._serialized_start = 555
-    _globals["_SWAPPARAMETERSREQUEST"]._serialized_end = 578
-    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_start = 580
-    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_end = 646
-    _globals["_SWAPPER"]._serialized_start = 649
-    _globals["_SWAPPER"]._serialized_end = 929
+    _globals["_CREATESWAPREQUEST"]._serialized_end = 93
+    _globals["_CREATESWAPRESPONSE"]._serialized_start = 95
+    _globals["_CREATESWAPRESPONSE"]._serialized_end = 217
+    _globals["_PAYSWAPREQUEST"]._serialized_start = 219
+    _globals["_PAYSWAPREQUEST"]._serialized_end = 260
+    _globals["_PAYSWAPRESPONSE"]._serialized_start = 262
+    _globals["_PAYSWAPRESPONSE"]._serialized_end = 279
+    _globals["_REFUNDSWAPREQUEST"]._serialized_start = 281
+    _globals["_REFUNDSWAPREQUEST"]._serialized_end = 378
+    _globals["_REFUNDSWAPRESPONSE"]._serialized_start = 380
+    _globals["_REFUNDSWAPRESPONSE"]._serialized_end = 446
+    _globals["_SWAPPARAMETERS"]._serialized_start = 448
+    _globals["_SWAPPARAMETERS"]._serialized_end = 570
+    _globals["_SWAPPARAMETERSREQUEST"]._serialized_start = 572
+    _globals["_SWAPPARAMETERSREQUEST"]._serialized_end = 595
+    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_start = 597
+    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_end = 663
+    _globals["_SWAPPER"]._serialized_start = 666
+    _globals["_SWAPPER"]._serialized_end = 946
 # @@protoc_insertion_point(module_scope)

--- a/itest/tests/swap_pb2.py
+++ b/itest/tests/swap_pb2.py
@@ -19,7 +19,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\nswap.proto\x12\x04swap"I\n\x11\x43reateSwapRequest\x12\x0c\n\x04hash\x18\x01 \x01(\x0c\x12\x15\n\rrefund_pubkey\x18\x02 \x01(\x0c\x12\x0f\n\x07invoice\x18\x03 \x01(\t"z\n\x12\x43reateSwapResponse\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x14\n\x0c\x63laim_pubkey\x18\x02 \x01(\x0c\x12\x13\n\x0block_height\x18\x03 \x01(\r\x12(\n\nparameters\x18\x04 \x01(\x0b\x32\x14.swap.SwapParameters")\n\x0ePaySwapRequest\x12\x17\n\x0fpayment_request\x18\x01 \x01(\t"\x11\n\x0fPaySwapResponse"a\n\x11RefundSwapRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x13\n\x0btransaction\x18\x02 \x01(\x0c\x12\x13\n\x0binput_index\x18\x03 \x01(\r\x12\x11\n\tpub_nonce\x18\x04 \x01(\x0c"B\n\x12RefundSwapResponse\x12\x11\n\tpub_nonce\x18\x01 \x01(\x0c\x12\x19\n\x11partial_signature\x18\x02 \x01(\x0c"z\n\x0eSwapParameters\x12\x11\n\tlock_time\x18\x01 \x01(\r\x12\x1b\n\x13max_swap_amount_sat\x18\x02 \x01(\x04\x12\x1b\n\x13min_swap_amount_sat\x18\x03 \x01(\x04\x12\x1b\n\x13min_utxo_amount_sat\x18\x04 \x01(\x04"\x17\n\x15SwapParametersRequest"B\n\x16SwapParametersResponse\x12(\n\nparameters\x18\x01 \x01(\x0b\x32\x14.swap.SwapParameters2\x98\x02\n\x07Swapper\x12\x41\n\nCreateSwap\x12\x17.swap.CreateSwapRequest\x1a\x18.swap.CreateSwapResponse"\x00\x12\x38\n\x07PaySwap\x12\x14.swap.PaySwapRequest\x1a\x15.swap.PaySwapResponse"\x00\x12\x41\n\nRefundSwap\x12\x17.swap.RefundSwapRequest\x1a\x18.swap.RefundSwapResponse"\x00\x12M\n\x0eSwapParameters\x12\x1b.swap.SwapParametersRequest\x1a\x1c.swap.SwapParametersResponse"\x00\x62\x06proto3'
+    b'\n\nswap.proto\x12\x04swap"I\n\x11\x43reateSwapRequest\x12\x0c\n\x04hash\x18\x01 \x01(\x0c\x12\x15\n\rrefund_pubkey\x18\x02 \x01(\x0c\x12\x0f\n\x07invoice\x18\x03 \x01(\t"\x9f\x01\n\x12\x43reateSwapResponse\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x14\n\x0c\x63laim_pubkey\x18\x02 \x01(\x0c\x12\x13\n\x0block_height\x18\x03 \x01(\r\x12#\n\x1b\x65xpected_last_payout_height\x18\x04 \x01(\r\x12(\n\nparameters\x18\x05 \x01(\x0b\x32\x14.swap.SwapParameters")\n\x0ePaySwapRequest\x12\x17\n\x0fpayment_request\x18\x01 \x01(\t"\x11\n\x0fPaySwapResponse"a\n\x11RefundSwapRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x13\n\x0btransaction\x18\x02 \x01(\x0c\x12\x13\n\x0binput_index\x18\x03 \x01(\r\x12\x11\n\tpub_nonce\x18\x04 \x01(\x0c"B\n\x12RefundSwapResponse\x12\x11\n\tpub_nonce\x18\x01 \x01(\x0c\x12\x19\n\x11partial_signature\x18\x02 \x01(\x0c"z\n\x0eSwapParameters\x12\x11\n\tlock_time\x18\x01 \x01(\r\x12\x1b\n\x13max_swap_amount_sat\x18\x02 \x01(\x04\x12\x1b\n\x13min_swap_amount_sat\x18\x03 \x01(\x04\x12\x1b\n\x13min_utxo_amount_sat\x18\x04 \x01(\x04"\x17\n\x15SwapParametersRequest"B\n\x16SwapParametersResponse\x12(\n\nparameters\x18\x01 \x01(\x0b\x32\x14.swap.SwapParameters2\x98\x02\n\x07Swapper\x12\x41\n\nCreateSwap\x12\x17.swap.CreateSwapRequest\x1a\x18.swap.CreateSwapResponse"\x00\x12\x38\n\x07PaySwap\x12\x14.swap.PaySwapRequest\x1a\x15.swap.PaySwapResponse"\x00\x12\x41\n\nRefundSwap\x12\x17.swap.RefundSwapRequest\x1a\x18.swap.RefundSwapResponse"\x00\x12M\n\x0eSwapParameters\x12\x1b.swap.SwapParametersRequest\x1a\x1c.swap.SwapParametersResponse"\x00\x62\x06proto3'
 )
 
 _globals = globals()
@@ -29,22 +29,22 @@ if not _descriptor._USE_C_DESCRIPTORS:
     DESCRIPTOR._loaded_options = None
     _globals["_CREATESWAPREQUEST"]._serialized_start = 20
     _globals["_CREATESWAPREQUEST"]._serialized_end = 93
-    _globals["_CREATESWAPRESPONSE"]._serialized_start = 95
-    _globals["_CREATESWAPRESPONSE"]._serialized_end = 217
-    _globals["_PAYSWAPREQUEST"]._serialized_start = 219
-    _globals["_PAYSWAPREQUEST"]._serialized_end = 260
-    _globals["_PAYSWAPRESPONSE"]._serialized_start = 262
-    _globals["_PAYSWAPRESPONSE"]._serialized_end = 279
-    _globals["_REFUNDSWAPREQUEST"]._serialized_start = 281
-    _globals["_REFUNDSWAPREQUEST"]._serialized_end = 378
-    _globals["_REFUNDSWAPRESPONSE"]._serialized_start = 380
-    _globals["_REFUNDSWAPRESPONSE"]._serialized_end = 446
-    _globals["_SWAPPARAMETERS"]._serialized_start = 448
-    _globals["_SWAPPARAMETERS"]._serialized_end = 570
-    _globals["_SWAPPARAMETERSREQUEST"]._serialized_start = 572
-    _globals["_SWAPPARAMETERSREQUEST"]._serialized_end = 595
-    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_start = 597
-    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_end = 663
-    _globals["_SWAPPER"]._serialized_start = 666
-    _globals["_SWAPPER"]._serialized_end = 946
+    _globals["_CREATESWAPRESPONSE"]._serialized_start = 96
+    _globals["_CREATESWAPRESPONSE"]._serialized_end = 255
+    _globals["_PAYSWAPREQUEST"]._serialized_start = 257
+    _globals["_PAYSWAPREQUEST"]._serialized_end = 298
+    _globals["_PAYSWAPRESPONSE"]._serialized_start = 300
+    _globals["_PAYSWAPRESPONSE"]._serialized_end = 317
+    _globals["_REFUNDSWAPREQUEST"]._serialized_start = 319
+    _globals["_REFUNDSWAPREQUEST"]._serialized_end = 416
+    _globals["_REFUNDSWAPRESPONSE"]._serialized_start = 418
+    _globals["_REFUNDSWAPRESPONSE"]._serialized_end = 484
+    _globals["_SWAPPARAMETERS"]._serialized_start = 486
+    _globals["_SWAPPARAMETERS"]._serialized_end = 608
+    _globals["_SWAPPARAMETERSREQUEST"]._serialized_start = 610
+    _globals["_SWAPPARAMETERSREQUEST"]._serialized_end = 633
+    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_start = 635
+    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_end = 701
+    _globals["_SWAPPER"]._serialized_start = 704
+    _globals["_SWAPPER"]._serialized_end = 984
 # @@protoc_insertion_point(module_scope)

--- a/itest/tests/swap_pb2.pyi
+++ b/itest/tests/swap_pb2.pyi
@@ -25,20 +25,29 @@ class CreateSwapRequest(_message.Message):
     ) -> None: ...
 
 class CreateSwapResponse(_message.Message):
-    __slots__ = ("address", "claim_pubkey", "lock_height", "parameters")
+    __slots__ = (
+        "address",
+        "claim_pubkey",
+        "lock_height",
+        "expected_last_payout_height",
+        "parameters",
+    )
     ADDRESS_FIELD_NUMBER: _ClassVar[int]
     CLAIM_PUBKEY_FIELD_NUMBER: _ClassVar[int]
     LOCK_HEIGHT_FIELD_NUMBER: _ClassVar[int]
+    EXPECTED_LAST_PAYOUT_HEIGHT_FIELD_NUMBER: _ClassVar[int]
     PARAMETERS_FIELD_NUMBER: _ClassVar[int]
     address: str
     claim_pubkey: bytes
     lock_height: int
+    expected_last_payout_height: int
     parameters: SwapParameters
     def __init__(
         self,
         address: _Optional[str] = ...,
         claim_pubkey: _Optional[bytes] = ...,
         lock_height: _Optional[int] = ...,
+        expected_last_payout_height: _Optional[int] = ...,
         parameters: _Optional[_Union[SwapParameters, _Mapping]] = ...,
     ) -> None: ...
 

--- a/itest/tests/swap_pb2.pyi
+++ b/itest/tests/swap_pb2.pyi
@@ -10,13 +10,18 @@ from typing import (
 DESCRIPTOR: _descriptor.FileDescriptor
 
 class CreateSwapRequest(_message.Message):
-    __slots__ = ("hash", "refund_pubkey")
+    __slots__ = ("hash", "refund_pubkey", "invoice")
     HASH_FIELD_NUMBER: _ClassVar[int]
     REFUND_PUBKEY_FIELD_NUMBER: _ClassVar[int]
+    INVOICE_FIELD_NUMBER: _ClassVar[int]
     hash: bytes
     refund_pubkey: bytes
+    invoice: str
     def __init__(
-        self, hash: _Optional[bytes] = ..., refund_pubkey: _Optional[bytes] = ...
+        self,
+        hash: _Optional[bytes] = ...,
+        refund_pubkey: _Optional[bytes] = ...,
+        invoice: _Optional[str] = ...,
     ) -> None: ...
 
 class CreateSwapResponse(_message.Message):

--- a/itest/tests/swapd.py
+++ b/itest/tests/swapd.py
@@ -283,10 +283,12 @@ class SwapperGrpc(object):
         self.channel = grpc.insecure_channel(f"{host}:{port}")
         self.stub = SwapperStub(self.channel)
 
-    def create_swap(self, lightning_node, refund_pubkey, hash):
+    def create_swap(self, lightning_node, refund_pubkey, hash, invoice):
         node_id = lightning_node.info["id"]
         payload = swap_pb2.CreateSwapRequest(
-            hash=hash, refund_pubkey=bytes.fromhex(refund_pubkey)
+            hash=hash,
+            refund_pubkey=bytes.fromhex(refund_pubkey),
+            invoice=invoice,
         )
         return self.stub.CreateSwap(payload)
 

--- a/swapd/Cargo.toml
+++ b/swapd/Cargo.toml
@@ -10,7 +10,7 @@ clap = { workspace = true, features = ["derive"] }
 futures = "0.3.31"
 futures-util = "0.3.31"
 hex = { workspace = true }
-lightning-invoice = "0.32.0"
+lightning-invoice = "0.33.0"
 prost = { workspace = true }
 regex = "1.11.1"
 reqwest = { version = "0.12.9", features = ["json"] }

--- a/swapd/proto/swap/swap.proto
+++ b/swapd/proto/swap/swap.proto
@@ -14,6 +14,13 @@ message CreateSwapRequest {
 
     // Public key used for unilateral refunds and cooperative spends.
     bytes refund_pubkey = 2;
+
+    // Any invoice to the client's node. This invoice is used to ensure the
+    // destination for the swap payout is the same as on swap creation. The
+    // invoice should have equivalent values for routing hints and 
+    // min_final_cltv_expiry_delta as the eventual invoice used for payout, so
+    // the swap server can give a good estimate of fees and timeouts. 
+    string invoice = 3;
 }
   
 message CreateSwapResponse {

--- a/swapd/proto/swap/swap.proto
+++ b/swapd/proto/swap/swap.proto
@@ -9,32 +9,53 @@ service Swapper {
 }
 
 message CreateSwapRequest {
+    // Hash for the HTLC. Client should have the preimage to this hash.
     bytes hash = 1;
+
+    // Public key used for unilateral refunds and cooperative spends.
     bytes refund_pubkey = 2;
 }
   
 message CreateSwapResponse {
+    // Funds sent to this address will be swapped over lightning.
     string address = 1;
+
+    // The swap server's public key for claiming the onchain funds after payout.
+    // The server side key for cooperative spends.
     bytes claim_pubkey = 2;
+
+    // Absolute blockheight after which the swap has expired, and is eligible
+    // for unilateral refund.
     uint32 lock_height = 3;
     SwapParameters parameters = 4;
 }
 
 message PaySwapRequest {
+    // Payment request to payout the swap funds over lightning.
     string payment_request = 1;
 }
 
 message PaySwapResponse {}
 
 message RefundSwapRequest {
+    // Which address to refund.
     string address = 1;
+
+    // The refund transaction.
     bytes transaction = 2;
+
+    // The input in the refund transaction spending from the swap address. 
     uint32 input_index = 3;
+
+    // Client's pub nonce used for the musig2 signature.
     bytes pub_nonce = 4;
 }
 
 message RefundSwapResponse {
+    // Server's pub nonce used for the musig2 signature.
     bytes pub_nonce = 1;
+
+    // Server's partial musig2 signature.
     bytes partial_signature = 2;
 }
 

--- a/swapd/proto/swap/swap.proto
+++ b/swapd/proto/swap/swap.proto
@@ -34,7 +34,10 @@ message CreateSwapResponse {
     // Absolute blockheight after which the swap has expired, and is eligible
     // for unilateral refund.
     uint32 lock_height = 3;
-    SwapParameters parameters = 4;
+
+    // Expected last block height where a payout is still possible.
+    uint32 expected_last_payout_height = 4;
+    SwapParameters parameters = 5;
 }
 
 message PaySwapRequest {

--- a/swapd/src/lightning/client.rs
+++ b/swapd/src/lightning/client.rs
@@ -1,10 +1,12 @@
 use bitcoin::hashes::sha256;
+use lightning_invoice::Bolt11Invoice;
 use tonic::Status;
 
 #[derive(Debug)]
 pub enum LightningError {
     ConnectionFailed,
     InvalidPreimage,
+    NoRoute,
     General(Status),
 }
 
@@ -30,12 +32,19 @@ pub struct PreimageResult {
     pub label: String,
 }
 
+#[derive(Debug)]
+pub struct Route {
+    // The total delay over the route.
+    pub delay: u32,
+}
+
 #[async_trait::async_trait]
 pub trait LightningClient {
     async fn get_preimage(
         &self,
         hash: sha256::Hash,
     ) -> Result<Option<PreimageResult>, LightningError>;
+    async fn get_route(&self, bolt11: &Bolt11Invoice) -> Result<Route, LightningError>;
     async fn has_pending_or_complete_payment(
         &self,
         hash: &sha256::Hash,

--- a/swapd/src/lightning/mod.rs
+++ b/swapd/src/lightning/mod.rs
@@ -1,2 +1,4 @@
 mod client;
-pub use client::{LightningClient, LightningError, PaymentRequest, PaymentResult, PreimageResult};
+pub use client::{
+    LightningClient, LightningError, PaymentRequest, PaymentResult, PreimageResult, Route,
+};

--- a/swapd/src/postgresql/migrations/20241206_initial.up.sql
+++ b/swapd/src/postgresql/migrations/20241206_initial.up.sql
@@ -9,6 +9,7 @@ CREATE TABLE swaps (
     claim_pubkey BYTEA NOT NULL,
     claim_script BYTEA NOT NULL,
     creation_time BIGINT NOT NULL,
+    destination BYTEA NOT NULL,
     lock_height BIGINT NOT NULL,
     payment_hash BYTEA NOT NULL PRIMARY KEY,
     preimage BYTEA NULL,

--- a/swapd/src/postgresql/swap_repository.rs
+++ b/swapd/src/postgresql/swap_repository.rs
@@ -40,6 +40,7 @@ impl SwapRepository {
         let claim_pubkey: Vec<u8> = row.try_get("claim_pubkey")?;
         let claim_script: Vec<u8> = row.try_get("claim_script")?;
         let creation_time: i64 = row.try_get("creation_time")?;
+        let destination: Vec<u8> = row.try_get("destination")?;
         let lock_height: i64 = row.try_get("lock_height")?;
         let payment_hash: Vec<u8> = row.try_get("payment_hash")?;
         let refund_pubkey: Vec<u8> = row.try_get("refund_pubkey")?;
@@ -53,6 +54,7 @@ impl SwapRepository {
             .require_network(self.network)?;
         let swap = Swap {
             creation_time,
+            destination: PublicKey::from_slice(&destination)?,
             public: SwapPublicData {
                 address: address.clone(),
                 claim_pubkey: PublicKey::from_slice(&claim_pubkey)?,
@@ -91,17 +93,19 @@ impl crate::swap::SwapRepository for SwapRepository {
                ,                  claim_pubkey
                ,                  claim_script
                ,                  creation_time
+               ,                  destination
                ,                  lock_height
                ,                  payment_hash
                ,                  refund_pubkey
                ,                  refund_script
-               ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)"#,
+               ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"#,
         )
         .bind(swap.public.address.to_string())
         .bind(swap.private.claim_privkey.secret_bytes().to_vec())
         .bind(swap.public.claim_pubkey.serialize())
         .bind(swap.public.claim_script.as_bytes())
         .bind(swap.creation_time.duration_since(UNIX_EPOCH)?.as_secs() as i64)
+        .bind(swap.destination.serialize())
         .bind(swap.public.lock_height as i64)
         .bind(swap.public.hash.as_byte_array().to_vec())
         .bind(swap.public.refund_pubkey.serialize())

--- a/swapd/src/postgresql/swap_repository.rs
+++ b/swapd/src/postgresql/swap_repository.rs
@@ -489,6 +489,7 @@ fn swap_state_fields(prefix: &str) -> String {
          , {0}.claim_pubkey
          , {0}.claim_script
          , {0}.creation_time
+         , {0}.destination
          , {0}.lock_height
          , {0}.payment_hash
          , {0}.preimage

--- a/swapd/src/public_server.rs
+++ b/swapd/src/public_server.rs
@@ -176,7 +176,6 @@ where
             Status::invalid_argument("invalid hash")
         })?;
 
-        // Get a fee estimate for the next block to account for worst case fees.
         let current_height = self.chain_client.get_blockheight().await?;
 
         let swap = self

--- a/swapd/src/public_server.rs
+++ b/swapd/src/public_server.rs
@@ -186,11 +186,10 @@ where
                 Status::internal("internal error")
             })?;
 
-        // TODO: These need to go in a transaction.
+        self.swap_repository.add_swap(&swap).await?;
         self.chain_repository
             .add_watch_address(&swap.public.address)
             .await?;
-        self.swap_repository.add_swap(&swap).await?;
 
         info!(
             hash = field::display(&hash),

--- a/swapd/src/public_server.rs
+++ b/swapd/src/public_server.rs
@@ -289,6 +289,10 @@ where
 
         let hash = invoice.payment_hash();
         let swap_state = self.swap_repository.get_swap_by_hash(hash).await?;
+        if swap_state.swap.destination != invoice.get_payee_pub_key() {
+            return Err(Status::invalid_argument("invalid destination"));
+        }
+
         if swap_state.preimage.is_some() {
             trace!("swap already had preimage");
             return Err(Status::failed_precondition("swap already paid"));

--- a/swapd/src/swap/swap_service.rs
+++ b/swapd/src/swap/swap_service.rs
@@ -45,6 +45,7 @@ impl SwapState {
 #[derive(Clone, Debug)]
 pub struct Swap {
     pub creation_time: SystemTime,
+    pub destination: PublicKey,
     pub public: SwapPublicData,
     pub private: SwapPrivateData,
 }
@@ -143,6 +144,7 @@ where
         refund_pubkey: PublicKey,
         hash: sha256::Hash,
         current_height: u64,
+        destination: PublicKey,
     ) -> Result<Swap, SwapError> {
         let creation_time = SystemTime::now();
         let claim_privkey = self.privkey_provider.new_private_key()?;
@@ -175,6 +177,7 @@ where
         );
         let mut swap = Swap {
             creation_time,
+            destination,
             public: SwapPublicData {
                 address: fake_address,
                 claim_pubkey,


### PR DESCRIPTION
The client adds a random invoice to the create_swap request.
From that random invoice the final cltv, the destination and the expected route to the destination are extracted.
Now create_swap returns the expected last payout height for indication when the last payout time is.
Also it is now enforced that the destination of the swap payout is the same as the one that created it. 