### PR TITLE
Use a relative timelock

### DIFF
--- a/itest/tests/helpers.py
+++ b/itest/tests/helpers.py
@@ -66,7 +66,7 @@ def create_swap_no_invoice_extended(user: ClnNode, swapper: SwapdServer):
         h.hex(),
         refund_privkey,
         create_swap_resp.claim_pubkey,
-        create_swap_resp.lock_height,
+        create_swap_resp.lock_time,
     )
 
 
@@ -76,7 +76,7 @@ def create_swap_no_invoice(user: ClnNode, swapper: SwapdServer):
 
 
 def create_swap_extended(user: ClnNode, swapper: SwapdServer, amount=100_000_000):
-    address, preimage, h, refund_privkey, claim_pubkey, lock_height = (
+    address, preimage, h, refund_privkey, claim_pubkey, lock_time = (
         create_swap_no_invoice_extended(user, swapper)
     )
     payment_request = user.create_invoice(
@@ -84,7 +84,7 @@ def create_swap_extended(user: ClnNode, swapper: SwapdServer, amount=100_000_000
         description="test",
         preimage=preimage,
     )
-    return address, payment_request, h, refund_privkey, claim_pubkey, lock_height
+    return address, payment_request, h, refund_privkey, claim_pubkey, lock_time
 
 
 def create_swap(user: ClnNode, swapper: SwapdServer, amount=100_000_000):

--- a/itest/tests/musig2.py
+++ b/itest/tests/musig2.py
@@ -213,6 +213,11 @@ KeyAggContext = NamedTuple(
 )
 
 
+def get_pk(keyagg_ctx: KeyAggContext) -> PlainPk:
+    Q, _, _ = keyagg_ctx
+    return PlainPk(cbytes(Q))
+
+
 def get_xonly_pk(keyagg_ctx: KeyAggContext) -> XonlyPk:
     Q, _, _ = keyagg_ctx
     return XonlyPk(xbytes(Q))

--- a/itest/tests/swap_internal_pb2.py
+++ b/itest/tests/swap_internal_pb2.py
@@ -19,7 +19,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\x13swap_internal.proto\x12\rswap_internal"-\n\x18\x41\x64\x64\x41\x64\x64ressFiltersRequest\x12\x11\n\taddresses\x18\x01 \x03(\t"\x1b\n\x19\x41\x64\x64\x41\x64\x64ressFiltersResponse"\x10\n\x0eGetInfoRequest"8\n\x0fGetInfoResponse\x12\x14\n\x0c\x62lock_height\x18\x01 \x01(\x04\x12\x0f\n\x07network\x18\x02 \x01(\t"\x90\x01\n\x0eGetSwapRequest\x12\x14\n\x07\x61\x64\x64ress\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x0fpayment_request\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x19\n\x0cpayment_hash\x18\x03 \x01(\x0cH\x02\x88\x01\x01\x42\n\n\x08_addressB\x12\n\x10_payment_requestB\x0f\n\r_payment_hash"N\n\x0fGetSwapResponse\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12*\n\x07outputs\x18\x02 \x03(\x0b\x32\x19.swap_internal.SwapOutput"\x80\x01\n\nSwapOutput\x12\x10\n\x08outpoint\x18\x01 \x01(\t\x12 \n\x13\x63onfirmation_height\x18\x02 \x01(\x04H\x00\x88\x01\x01\x12\x17\n\nblock_hash\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x16\n\x14_confirmation_heightB\r\n\x0b_block_hash"\x16\n\x14ListClaimableRequest"I\n\x15ListClaimableResponse\x12\x30\n\nclaimables\x18\x01 \x03(\x0b\x32\x1c.swap_internal.ClaimableUtxo"\xc5\x01\n\rClaimableUtxo\x12\x10\n\x08outpoint\x18\x01 \x01(\t\x12\x11\n\tswap_hash\x18\x02 \x01(\t\x12\x13\n\x0block_height\x18\x03 \x01(\r\x12\x1b\n\x13\x63onfirmation_height\x18\x04 \x01(\x04\x12\x12\n\nblock_hash\x18\x05 \x01(\t\x12\x13\n\x0b\x62locks_left\x18\x06 \x01(\x05\x12\x1e\n\x11paid_with_request\x18\x07 \x01(\tH\x00\x88\x01\x01\x42\x14\n\x12_paid_with_request"\x96\x01\n\x0c\x43laimRequest\x12\x11\n\toutpoints\x18\x01 \x03(\t\x12 \n\x13\x64\x65stination_address\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x17\n\nfee_per_kw\x18\x03 \x01(\rH\x01\x88\x01\x01\x12\x11\n\tauto_bump\x18\x04 \x01(\x08\x42\x16\n\x14_destination_addressB\r\n\x0b_fee_per_kw"2\n\rClaimResponse\x12\r\n\x05tx_id\x18\x01 \x01(\t\x12\x12\n\nfee_per_kw\x18\x02 \x01(\r"\r\n\x0bStopRequest"\x0e\n\x0cStopResponse2\xf6\x03\n\x0bSwapManager\x12h\n\x11\x41\x64\x64\x41\x64\x64ressFilters\x12\'.swap_internal.AddAddressFiltersRequest\x1a(.swap_internal.AddAddressFiltersResponse"\x00\x12J\n\x07GetInfo\x12\x1d.swap_internal.GetInfoRequest\x1a\x1e.swap_internal.GetInfoResponse"\x00\x12J\n\x07GetSwap\x12\x1d.swap_internal.GetSwapRequest\x1a\x1e.swap_internal.GetSwapResponse"\x00\x12\\\n\rListClaimable\x12#.swap_internal.ListClaimableRequest\x1a$.swap_internal.ListClaimableResponse"\x00\x12\x44\n\x05\x43laim\x12\x1b.swap_internal.ClaimRequest\x1a\x1c.swap_internal.ClaimResponse"\x00\x12\x41\n\x04Stop\x12\x1a.swap_internal.StopRequest\x1a\x1b.swap_internal.StopResponse"\x00\x62\x06proto3'
+    b'\n\x13swap_internal.proto\x12\rswap_internal"-\n\x18\x41\x64\x64\x41\x64\x64ressFiltersRequest\x12\x11\n\taddresses\x18\x01 \x03(\t"\x1b\n\x19\x41\x64\x64\x41\x64\x64ressFiltersResponse"\x10\n\x0eGetInfoRequest"8\n\x0fGetInfoResponse\x12\x14\n\x0c\x62lock_height\x18\x01 \x01(\x04\x12\x0f\n\x07network\x18\x02 \x01(\t"\x90\x01\n\x0eGetSwapRequest\x12\x14\n\x07\x61\x64\x64ress\x18\x01 \x01(\tH\x00\x88\x01\x01\x12\x1c\n\x0fpayment_request\x18\x02 \x01(\tH\x01\x88\x01\x01\x12\x19\n\x0cpayment_hash\x18\x03 \x01(\x0cH\x02\x88\x01\x01\x42\n\n\x08_addressB\x12\n\x10_payment_requestB\x0f\n\r_payment_hash"N\n\x0fGetSwapResponse\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12*\n\x07outputs\x18\x02 \x03(\x0b\x32\x19.swap_internal.SwapOutput"\x80\x01\n\nSwapOutput\x12\x10\n\x08outpoint\x18\x01 \x01(\t\x12 \n\x13\x63onfirmation_height\x18\x02 \x01(\x04H\x00\x88\x01\x01\x12\x17\n\nblock_hash\x18\x03 \x01(\tH\x01\x88\x01\x01\x42\x16\n\x14_confirmation_heightB\r\n\x0b_block_hash"\x16\n\x14ListClaimableRequest"I\n\x15ListClaimableResponse\x12\x30\n\nclaimables\x18\x01 \x03(\x0b\x32\x1c.swap_internal.ClaimableUtxo"\xc3\x01\n\rClaimableUtxo\x12\x10\n\x08outpoint\x18\x01 \x01(\t\x12\x11\n\tswap_hash\x18\x02 \x01(\t\x12\x11\n\tlock_time\x18\x03 \x01(\r\x12\x1b\n\x13\x63onfirmation_height\x18\x04 \x01(\x04\x12\x12\n\nblock_hash\x18\x05 \x01(\t\x12\x13\n\x0b\x62locks_left\x18\x06 \x01(\x05\x12\x1e\n\x11paid_with_request\x18\x07 \x01(\tH\x00\x88\x01\x01\x42\x14\n\x12_paid_with_request"\x96\x01\n\x0c\x43laimRequest\x12\x11\n\toutpoints\x18\x01 \x03(\t\x12 \n\x13\x64\x65stination_address\x18\x02 \x01(\tH\x00\x88\x01\x01\x12\x17\n\nfee_per_kw\x18\x03 \x01(\rH\x01\x88\x01\x01\x12\x11\n\tauto_bump\x18\x04 \x01(\x08\x42\x16\n\x14_destination_addressB\r\n\x0b_fee_per_kw"2\n\rClaimResponse\x12\r\n\x05tx_id\x18\x01 \x01(\t\x12\x12\n\nfee_per_kw\x18\x02 \x01(\r"\r\n\x0bStopRequest"\x0e\n\x0cStopResponse2\xf6\x03\n\x0bSwapManager\x12h\n\x11\x41\x64\x64\x41\x64\x64ressFilters\x12\'.swap_internal.AddAddressFiltersRequest\x1a(.swap_internal.AddAddressFiltersResponse"\x00\x12J\n\x07GetInfo\x12\x1d.swap_internal.GetInfoRequest\x1a\x1e.swap_internal.GetInfoResponse"\x00\x12J\n\x07GetSwap\x12\x1d.swap_internal.GetSwapRequest\x1a\x1e.swap_internal.GetSwapResponse"\x00\x12\\\n\rListClaimable\x12#.swap_internal.ListClaimableRequest\x1a$.swap_internal.ListClaimableResponse"\x00\x12\x44\n\x05\x43laim\x12\x1b.swap_internal.ClaimRequest\x1a\x1c.swap_internal.ClaimResponse"\x00\x12\x41\n\x04Stop\x12\x1a.swap_internal.StopRequest\x1a\x1b.swap_internal.StopResponse"\x00\x62\x06proto3'
 )
 
 _globals = globals()
@@ -46,15 +46,15 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_LISTCLAIMABLERESPONSE"]._serialized_start = 572
     _globals["_LISTCLAIMABLERESPONSE"]._serialized_end = 645
     _globals["_CLAIMABLEUTXO"]._serialized_start = 648
-    _globals["_CLAIMABLEUTXO"]._serialized_end = 845
-    _globals["_CLAIMREQUEST"]._serialized_start = 848
-    _globals["_CLAIMREQUEST"]._serialized_end = 998
-    _globals["_CLAIMRESPONSE"]._serialized_start = 1000
-    _globals["_CLAIMRESPONSE"]._serialized_end = 1050
-    _globals["_STOPREQUEST"]._serialized_start = 1052
-    _globals["_STOPREQUEST"]._serialized_end = 1065
-    _globals["_STOPRESPONSE"]._serialized_start = 1067
-    _globals["_STOPRESPONSE"]._serialized_end = 1081
-    _globals["_SWAPMANAGER"]._serialized_start = 1084
-    _globals["_SWAPMANAGER"]._serialized_end = 1586
+    _globals["_CLAIMABLEUTXO"]._serialized_end = 843
+    _globals["_CLAIMREQUEST"]._serialized_start = 846
+    _globals["_CLAIMREQUEST"]._serialized_end = 996
+    _globals["_CLAIMRESPONSE"]._serialized_start = 998
+    _globals["_CLAIMRESPONSE"]._serialized_end = 1048
+    _globals["_STOPREQUEST"]._serialized_start = 1050
+    _globals["_STOPREQUEST"]._serialized_end = 1063
+    _globals["_STOPRESPONSE"]._serialized_start = 1065
+    _globals["_STOPRESPONSE"]._serialized_end = 1079
+    _globals["_SWAPMANAGER"]._serialized_start = 1082
+    _globals["_SWAPMANAGER"]._serialized_end = 1584
 # @@protoc_insertion_point(module_scope)

--- a/itest/tests/swap_internal_pb2.pyi
+++ b/itest/tests/swap_internal_pb2.pyi
@@ -93,7 +93,7 @@ class ClaimableUtxo(_message.Message):
     __slots__ = (
         "outpoint",
         "swap_hash",
-        "lock_height",
+        "lock_time",
         "confirmation_height",
         "block_hash",
         "blocks_left",
@@ -101,14 +101,14 @@ class ClaimableUtxo(_message.Message):
     )
     OUTPOINT_FIELD_NUMBER: _ClassVar[int]
     SWAP_HASH_FIELD_NUMBER: _ClassVar[int]
-    LOCK_HEIGHT_FIELD_NUMBER: _ClassVar[int]
+    LOCK_TIME_FIELD_NUMBER: _ClassVar[int]
     CONFIRMATION_HEIGHT_FIELD_NUMBER: _ClassVar[int]
     BLOCK_HASH_FIELD_NUMBER: _ClassVar[int]
     BLOCKS_LEFT_FIELD_NUMBER: _ClassVar[int]
     PAID_WITH_REQUEST_FIELD_NUMBER: _ClassVar[int]
     outpoint: str
     swap_hash: str
-    lock_height: int
+    lock_time: int
     confirmation_height: int
     block_hash: str
     blocks_left: int
@@ -117,7 +117,7 @@ class ClaimableUtxo(_message.Message):
         self,
         outpoint: _Optional[str] = ...,
         swap_hash: _Optional[str] = ...,
-        lock_height: _Optional[int] = ...,
+        lock_time: _Optional[int] = ...,
         confirmation_height: _Optional[int] = ...,
         block_hash: _Optional[str] = ...,
         blocks_left: _Optional[int] = ...,

--- a/itest/tests/swap_pb2.py
+++ b/itest/tests/swap_pb2.py
@@ -19,7 +19,7 @@ _sym_db = _symbol_database.Default()
 
 
 DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(
-    b'\n\nswap.proto\x12\x04swap"8\n\x11\x43reateSwapRequest\x12\x0c\n\x04hash\x18\x01 \x01(\x0c\x12\x15\n\rrefund_pubkey\x18\x02 \x01(\x0c"z\n\x12\x43reateSwapResponse\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x14\n\x0c\x63laim_pubkey\x18\x02 \x01(\x0c\x12\x13\n\x0block_height\x18\x03 \x01(\r\x12(\n\nparameters\x18\x04 \x01(\x0b\x32\x14.swap.SwapParameters")\n\x0ePaySwapRequest\x12\x17\n\x0fpayment_request\x18\x01 \x01(\t"\x11\n\x0fPaySwapResponse"a\n\x11RefundSwapRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x13\n\x0btransaction\x18\x02 \x01(\x0c\x12\x13\n\x0binput_index\x18\x03 \x01(\r\x12\x11\n\tpub_nonce\x18\x04 \x01(\x0c"B\n\x12RefundSwapResponse\x12\x11\n\tpub_nonce\x18\x01 \x01(\x0c\x12\x19\n\x11partial_signature\x18\x02 \x01(\x0c"z\n\x0eSwapParameters\x12\x11\n\tlock_time\x18\x01 \x01(\r\x12\x1b\n\x13max_swap_amount_sat\x18\x02 \x01(\x04\x12\x1b\n\x13min_swap_amount_sat\x18\x03 \x01(\x04\x12\x1b\n\x13min_utxo_amount_sat\x18\x04 \x01(\x04"\x17\n\x15SwapParametersRequest"B\n\x16SwapParametersResponse\x12(\n\nparameters\x18\x01 \x01(\x0b\x32\x14.swap.SwapParameters2\x98\x02\n\x07Swapper\x12\x41\n\nCreateSwap\x12\x17.swap.CreateSwapRequest\x1a\x18.swap.CreateSwapResponse"\x00\x12\x38\n\x07PaySwap\x12\x14.swap.PaySwapRequest\x1a\x15.swap.PaySwapResponse"\x00\x12\x41\n\nRefundSwap\x12\x17.swap.RefundSwapRequest\x1a\x18.swap.RefundSwapResponse"\x00\x12M\n\x0eSwapParameters\x12\x1b.swap.SwapParametersRequest\x1a\x1c.swap.SwapParametersResponse"\x00\x62\x06proto3'
+    b'\n\nswap.proto\x12\x04swap"8\n\x11\x43reateSwapRequest\x12\x0c\n\x04hash\x18\x01 \x01(\x0c\x12\x15\n\rrefund_pubkey\x18\x02 \x01(\x0c"x\n\x12\x43reateSwapResponse\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x14\n\x0c\x63laim_pubkey\x18\x02 \x01(\x0c\x12\x11\n\tlock_time\x18\x03 \x01(\r\x12(\n\nparameters\x18\x04 \x01(\x0b\x32\x14.swap.SwapParameters")\n\x0ePaySwapRequest\x12\x17\n\x0fpayment_request\x18\x01 \x01(\t"\x11\n\x0fPaySwapResponse"a\n\x11RefundSwapRequest\x12\x0f\n\x07\x61\x64\x64ress\x18\x01 \x01(\t\x12\x13\n\x0btransaction\x18\x02 \x01(\x0c\x12\x13\n\x0binput_index\x18\x03 \x01(\r\x12\x11\n\tpub_nonce\x18\x04 \x01(\x0c"B\n\x12RefundSwapResponse\x12\x11\n\tpub_nonce\x18\x01 \x01(\x0c\x12\x19\n\x11partial_signature\x18\x02 \x01(\x0c"g\n\x0eSwapParameters\x12\x1b\n\x13max_swap_amount_sat\x18\x01 \x01(\x04\x12\x1b\n\x13min_swap_amount_sat\x18\x02 \x01(\x04\x12\x1b\n\x13min_utxo_amount_sat\x18\x03 \x01(\x04"\x17\n\x15SwapParametersRequest"B\n\x16SwapParametersResponse\x12(\n\nparameters\x18\x01 \x01(\x0b\x32\x14.swap.SwapParameters2\x98\x02\n\x07Swapper\x12\x41\n\nCreateSwap\x12\x17.swap.CreateSwapRequest\x1a\x18.swap.CreateSwapResponse"\x00\x12\x38\n\x07PaySwap\x12\x14.swap.PaySwapRequest\x1a\x15.swap.PaySwapResponse"\x00\x12\x41\n\nRefundSwap\x12\x17.swap.RefundSwapRequest\x1a\x18.swap.RefundSwapResponse"\x00\x12M\n\x0eSwapParameters\x12\x1b.swap.SwapParametersRequest\x1a\x1c.swap.SwapParametersResponse"\x00\x62\x06proto3'
 )
 
 _globals = globals()
@@ -30,21 +30,21 @@ if not _descriptor._USE_C_DESCRIPTORS:
     _globals["_CREATESWAPREQUEST"]._serialized_start = 20
     _globals["_CREATESWAPREQUEST"]._serialized_end = 76
     _globals["_CREATESWAPRESPONSE"]._serialized_start = 78
-    _globals["_CREATESWAPRESPONSE"]._serialized_end = 200
-    _globals["_PAYSWAPREQUEST"]._serialized_start = 202
-    _globals["_PAYSWAPREQUEST"]._serialized_end = 243
-    _globals["_PAYSWAPRESPONSE"]._serialized_start = 245
-    _globals["_PAYSWAPRESPONSE"]._serialized_end = 262
-    _globals["_REFUNDSWAPREQUEST"]._serialized_start = 264
-    _globals["_REFUNDSWAPREQUEST"]._serialized_end = 361
-    _globals["_REFUNDSWAPRESPONSE"]._serialized_start = 363
-    _globals["_REFUNDSWAPRESPONSE"]._serialized_end = 429
-    _globals["_SWAPPARAMETERS"]._serialized_start = 431
-    _globals["_SWAPPARAMETERS"]._serialized_end = 553
-    _globals["_SWAPPARAMETERSREQUEST"]._serialized_start = 555
-    _globals["_SWAPPARAMETERSREQUEST"]._serialized_end = 578
-    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_start = 580
-    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_end = 646
-    _globals["_SWAPPER"]._serialized_start = 649
-    _globals["_SWAPPER"]._serialized_end = 929
+    _globals["_CREATESWAPRESPONSE"]._serialized_end = 198
+    _globals["_PAYSWAPREQUEST"]._serialized_start = 200
+    _globals["_PAYSWAPREQUEST"]._serialized_end = 241
+    _globals["_PAYSWAPRESPONSE"]._serialized_start = 243
+    _globals["_PAYSWAPRESPONSE"]._serialized_end = 260
+    _globals["_REFUNDSWAPREQUEST"]._serialized_start = 262
+    _globals["_REFUNDSWAPREQUEST"]._serialized_end = 359
+    _globals["_REFUNDSWAPRESPONSE"]._serialized_start = 361
+    _globals["_REFUNDSWAPRESPONSE"]._serialized_end = 427
+    _globals["_SWAPPARAMETERS"]._serialized_start = 429
+    _globals["_SWAPPARAMETERS"]._serialized_end = 532
+    _globals["_SWAPPARAMETERSREQUEST"]._serialized_start = 534
+    _globals["_SWAPPARAMETERSREQUEST"]._serialized_end = 557
+    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_start = 559
+    _globals["_SWAPPARAMETERSRESPONSE"]._serialized_end = 625
+    _globals["_SWAPPER"]._serialized_start = 628
+    _globals["_SWAPPER"]._serialized_end = 908
 # @@protoc_insertion_point(module_scope)

--- a/itest/tests/swap_pb2.pyi
+++ b/itest/tests/swap_pb2.pyi
@@ -20,20 +20,20 @@ class CreateSwapRequest(_message.Message):
     ) -> None: ...
 
 class CreateSwapResponse(_message.Message):
-    __slots__ = ("address", "claim_pubkey", "lock_height", "parameters")
+    __slots__ = ("address", "claim_pubkey", "lock_time", "parameters")
     ADDRESS_FIELD_NUMBER: _ClassVar[int]
     CLAIM_PUBKEY_FIELD_NUMBER: _ClassVar[int]
-    LOCK_HEIGHT_FIELD_NUMBER: _ClassVar[int]
+    LOCK_TIME_FIELD_NUMBER: _ClassVar[int]
     PARAMETERS_FIELD_NUMBER: _ClassVar[int]
     address: str
     claim_pubkey: bytes
-    lock_height: int
+    lock_time: int
     parameters: SwapParameters
     def __init__(
         self,
         address: _Optional[str] = ...,
         claim_pubkey: _Optional[bytes] = ...,
-        lock_height: _Optional[int] = ...,
+        lock_time: _Optional[int] = ...,
         parameters: _Optional[_Union[SwapParameters, _Mapping]] = ...,
     ) -> None: ...
 
@@ -78,23 +78,15 @@ class RefundSwapResponse(_message.Message):
     ) -> None: ...
 
 class SwapParameters(_message.Message):
-    __slots__ = (
-        "lock_time",
-        "max_swap_amount_sat",
-        "min_swap_amount_sat",
-        "min_utxo_amount_sat",
-    )
-    LOCK_TIME_FIELD_NUMBER: _ClassVar[int]
+    __slots__ = ("max_swap_amount_sat", "min_swap_amount_sat", "min_utxo_amount_sat")
     MAX_SWAP_AMOUNT_SAT_FIELD_NUMBER: _ClassVar[int]
     MIN_SWAP_AMOUNT_SAT_FIELD_NUMBER: _ClassVar[int]
     MIN_UTXO_AMOUNT_SAT_FIELD_NUMBER: _ClassVar[int]
-    lock_time: int
     max_swap_amount_sat: int
     min_swap_amount_sat: int
     min_utxo_amount_sat: int
     def __init__(
         self,
-        lock_time: _Optional[int] = ...,
         max_swap_amount_sat: _Optional[int] = ...,
         min_swap_amount_sat: _Optional[int] = ...,
         min_utxo_amount_sat: _Optional[int] = ...,

--- a/itest/tests/test_claim_rbf.py
+++ b/itest/tests/test_claim_rbf.py
@@ -43,7 +43,14 @@ def test_claim_rbf_close_to_deadline(node_factory, swapd_factory, lock_time):
         if len(memp) == 0:
             return False
         assert len(memp) == 1
-        return memp[0] != claim_txid1
+        claim_txid2 = memp[0]
+        if claim_txid2 == claim_txid1:
+            return False
+
+        claim_raw2 = swapper.lightning_node.bitcoin.rpc.getrawtransaction(
+            claim_txid2, True
+        )
+        return claim_raw2["vout"][0]["value"] != claim_raw1["vout"][0]["value"]
 
     wait_for(check_bumped)
     claim_txid2 = swapper.lightning_node.bitcoin.rpc.getrawmempool()[0]

--- a/itest/tests/test_cltv_limit.py
+++ b/itest/tests/test_cltv_limit.py
@@ -16,7 +16,7 @@ def test_below_cltv_limit(
         100_000_000,
         description="test",
         preimage=preimage,
-        cltv=lock_time - 1 - min_claim_blocks - min_viable_cltv + 1,
+        cltv=lock_time - min_claim_blocks - min_viable_cltv + 1,
     )
 
     try:
@@ -40,7 +40,7 @@ def test_on_cltv_limit(
         100_000_000,
         description="test",
         preimage=preimage,
-        cltv=lock_time - 1 - min_claim_blocks - min_viable_cltv,
+        cltv=lock_time - min_claim_blocks - min_viable_cltv,
     )
 
     swapper.rpc.pay_swap(payment_request)
@@ -63,7 +63,7 @@ def test_below_cltv_limit_with_router(
         100_000_000,
         description="test",
         preimage=preimage,
-        cltv=lock_time - 1 - min_claim_blocks - cltv_delta + 1,
+        cltv=lock_time - min_claim_blocks - cltv_delta + 1,
     )
 
     try:
@@ -92,7 +92,7 @@ def test_on_cltv_limit_with_router(
         100_000_000,
         description="test",
         preimage=preimage,
-        cltv=lock_time - 1 - min_claim_blocks - cltv_delta - 3,
+        cltv=lock_time - min_claim_blocks - cltv_delta - 3,
     )
 
     swapper.rpc.pay_swap(payment_request)

--- a/itest/tests/test_coop_refund.py
+++ b/itest/tests/test_coop_refund.py
@@ -19,7 +19,7 @@ def coop_refund(
     h,
     refund_privkey,
     claim_pubkey,
-    lock_height,
+    lock_time,
     to_spend_txid,
     refund_amount,
 ):
@@ -57,8 +57,8 @@ def coop_refund(
             [
                 refund_privkey.get_public_key().to_x_only_hex(),
                 "OP_CHECKSIGVERIFY",
-                lock_height,
-                "OP_CHECKLOCKTIMEVERIFY",
+                lock_time,
+                "OP_CHECKSEQUENCEVERIFY",
             ]
         ),
     ]
@@ -89,7 +89,7 @@ def coop_refund(
 def test_cooperative_refund_success(node_factory, swapd_factory):
     setup("regtest")
     user, swapper = setup_user_and_swapper(node_factory, swapd_factory)
-    address, _, h, refund_privkey, claim_pubkey, lock_height = (
+    address, _, h, refund_privkey, claim_pubkey, lock_time = (
         create_swap_no_invoice_extended(user, swapper)
     )
     to_spend_txid = user.bitcoin.rpc.sendtoaddress(address, 100_000 / 10**8)
@@ -104,7 +104,7 @@ def test_cooperative_refund_success(node_factory, swapd_factory):
         h,
         refund_privkey,
         claim_pubkey,
-        lock_height,
+        lock_time,
         to_spend_txid,
         99_000,
     )
@@ -118,7 +118,7 @@ def test_cooperative_refund_success(node_factory, swapd_factory):
 def test_cooperative_refund_rbf_success(node_factory, swapd_factory):
     setup("regtest")
     user, swapper = setup_user_and_swapper(node_factory, swapd_factory)
-    address, _, h, refund_privkey, claim_pubkey, lock_height = (
+    address, _, h, refund_privkey, claim_pubkey, lock_time = (
         create_swap_no_invoice_extended(user, swapper)
     )
     to_spend_txid = user.bitcoin.rpc.sendtoaddress(address, 100_000 / 10**8)
@@ -134,7 +134,7 @@ def test_cooperative_refund_rbf_success(node_factory, swapd_factory):
         h,
         refund_privkey,
         claim_pubkey,
-        lock_height,
+        lock_time,
         to_spend_txid,
         99_000,
     )
@@ -146,7 +146,7 @@ def test_cooperative_refund_rbf_success(node_factory, swapd_factory):
         h,
         refund_privkey,
         claim_pubkey,
-        lock_height,
+        lock_time,
         to_spend_txid,
         98_000,
     )
@@ -158,7 +158,7 @@ def test_cooperative_refund_rbf_success(node_factory, swapd_factory):
 def test_cooperative_refund_then_pay_failure(node_factory, swapd_factory):
     setup("regtest")
     user, swapper = setup_user_and_swapper(node_factory, swapd_factory)
-    address, payment_request, h, refund_privkey, claim_pubkey, lock_height = (
+    address, payment_request, h, refund_privkey, claim_pubkey, lock_time = (
         create_swap_extended(user, swapper)
     )
     to_spend_txid = user.bitcoin.rpc.sendtoaddress(address, 100_000 / 10**8)
@@ -173,7 +173,7 @@ def test_cooperative_refund_then_pay_failure(node_factory, swapd_factory):
         h,
         refund_privkey,
         claim_pubkey,
-        lock_height,
+        lock_time,
         to_spend_txid,
         99_000,
     )
@@ -187,7 +187,7 @@ def test_cooperative_refund_then_pay_failure(node_factory, swapd_factory):
 def test_pay_then_cooperative_refund_failure(node_factory, swapd_factory):
     setup("regtest")
     user, swapper = setup_user_and_swapper(node_factory, swapd_factory)
-    address, payment_request, h, refund_privkey, claim_pubkey, lock_height = (
+    address, payment_request, h, refund_privkey, claim_pubkey, lock_time = (
         create_swap_extended(user, swapper)
     )
     to_spend_txid = user.bitcoin.rpc.sendtoaddress(address, 100_000 / 10**8)
@@ -205,7 +205,7 @@ def test_pay_then_cooperative_refund_failure(node_factory, swapd_factory):
             h,
             refund_privkey,
             claim_pubkey,
-            lock_height,
+            lock_time,
             to_spend_txid,
             99_000,
         )

--- a/itest/tests/test_unilateral_refund.py
+++ b/itest/tests/test_unilateral_refund.py
@@ -1,0 +1,184 @@
+from helpers import *
+import grpc
+import musig2
+import os
+from bitcoinutils.constants import TYPE_RELATIVE_TIMELOCK
+from bitcoinutils.transactions import Locktime, Sequence
+from bitcoinutils.ripemd160 import ripemd160
+from bitcoinutils.script import Script, OP_CODES
+from bitcoinutils.utils import ControlBlock, get_tag_hashed_merkle_root, tagged_hash
+from bitcoinutils.setup import setup
+from bitcoinutils.keys import P2trAddress, PublicKey
+from bitcoinutils.transactions import Transaction, TxInput, TxOutput, TxWitnessInput
+from decimal import Decimal
+import struct
+
+
+def unilateral_refund(
+    user,
+    swapper,
+    address,
+    h,
+    refund_privkey,
+    claim_pubkey,
+    lock_time,
+    to_spend_txid,
+    refund_amount,
+    height,
+):
+    to_spend_tx = user.bitcoin.rpc.getrawtransaction(to_spend_txid, True)
+    to_spend_output_index = 0
+    if to_spend_tx["vout"][1]["value"] == Decimal("0.00100000"):
+        to_spend_output_index = 1
+
+    refund_address = P2trAddress(user.new_address())
+    extra_in = os.urandom(32)
+
+    tx_lock_time = struct.pack("<q", height).hex()[2:].zfill(8)
+    sequence = Sequence(TYPE_RELATIVE_TIMELOCK, lock_time).for_input_sequence()
+    print("AAAAA", sequence, tx_lock_time)
+    tx_in = TxInput(to_spend_txid, to_spend_output_index, sequence=sequence)
+    tx_out = TxOutput(refund_amount, refund_address.to_script_pub_key())
+    tx = Transaction([tx_in], [tx_out], has_segwit=True)
+
+    scripts = [
+        Script(
+            [
+                "OP_HASH160",
+                ripemd160(bytes.fromhex(h)).hex(),
+                "OP_EQUALVERIFY",
+                PublicKey(claim_pubkey.hex()).to_x_only_hex(),
+                "OP_CHECKSIG",
+            ]
+        ),
+        Script(
+            [
+                refund_privkey.get_public_key().to_x_only_hex(),
+                "OP_CHECKSIGVERIFY",
+                Sequence(TYPE_RELATIVE_TIMELOCK, lock_time).for_script(),
+                "OP_CHECKSEQUENCEVERIFY",
+            ]
+        ),
+    ]
+    sig = refund_privkey.sign_taproot_input(
+        tx,
+        0,
+        [P2trAddress(address).to_script_pub_key()],
+        [100_000],
+        script_path=True,
+        tapleaf_script=scripts[1],
+        tweak=False,
+    )
+
+    refund_pubkey_bytes = bytes.fromhex(refund_privkey.get_public_key().to_hex())
+    pubkeys = musig2.key_sort([claim_pubkey, refund_pubkey_bytes])
+    agg_ctx = musig2.key_agg(pubkeys)
+    aggpk = musig2.get_pk(agg_ctx)
+
+    control_block = ControlBlock(PublicKey(aggpk.hex()), scripts, 1, is_odd=True)
+    tx.witnesses.append(
+        TxWitnessInput([sig, scripts[1].to_hex(), control_block.to_hex()])
+    )
+
+    tx_odd = tx.to_hex()
+
+    control_block = ControlBlock(PublicKey(aggpk.hex()), scripts, 1, is_odd=False)
+    tx.witnesses.clear()
+    tx.witnesses.append(
+        TxWitnessInput([sig, scripts[1].to_hex(), control_block.to_hex()])
+    )
+
+    tx_even = tx.to_hex()
+
+    # TODO(JssDWt): I could not figure out which value to use for is_odd. Decided to use both.
+    return tx_odd, tx_even
+
+
+def test_unilateral_refund_success(node_factory, swapd_factory):
+    setup("regtest")
+    user, swapper = setup_user_and_swapper(node_factory, swapd_factory)
+    address, _, h, refund_privkey, claim_pubkey, lock_time = (
+        create_swap_no_invoice_extended(user, swapper)
+    )
+    to_spend_txid = user.bitcoin.rpc.sendtoaddress(address, 100_000 / 10**8)
+    user.bitcoin.generate_block(1)
+
+    wait_for(lambda: len(swapper.internal_rpc.get_swap(address).outputs) > 0)
+
+    height = user.bitcoin.rpc.getblockcount()
+    blocks_to_add = lock_time - 1
+    new_height = height + blocks_to_add
+    user.bitcoin.generate_block(blocks_to_add)
+    user.bitcoin.wait_for_log(r"UpdateTip: new best=.* height={}".format(new_height))
+    tx_odd, tx_even = unilateral_refund(
+        user,
+        swapper,
+        address,
+        h,
+        refund_privkey,
+        claim_pubkey,
+        lock_time,
+        to_spend_txid,
+        99_000,
+        new_height,
+    )
+
+    expected_utxos = len(user.list_utxos()) + 1
+    try:
+        user.bitcoin.rpc.sendrawtransaction(tx_odd)
+    except Exception as e:
+        if "Witness program hash mismatch" in str(e):
+            user.bitcoin.rpc.sendrawtransaction(tx_even)
+        else:
+            raise
+    user.bitcoin.generate_block(1)
+    wait_for(lambda: len(user.list_utxos()) == expected_utxos)
+
+
+def test_unilateral_refund_too_soon(node_factory, swapd_factory):
+    setup("regtest")
+    user, swapper = setup_user_and_swapper(node_factory, swapd_factory)
+    address, _, h, refund_privkey, claim_pubkey, lock_time = (
+        create_swap_no_invoice_extended(user, swapper)
+    )
+    to_spend_txid = user.bitcoin.rpc.sendtoaddress(address, 100_000 / 10**8)
+    user.bitcoin.generate_block(1)
+
+    wait_for(lambda: len(swapper.internal_rpc.get_swap(address).outputs) > 0)
+
+    height = user.bitcoin.rpc.getblockcount()
+    blocks_to_add = lock_time - 2
+    new_height = height + blocks_to_add
+    user.bitcoin.generate_block(blocks_to_add)
+    user.bitcoin.wait_for_log(r"UpdateTip: new best=.* height={}".format(new_height))
+    tx_odd, tx_even = unilateral_refund(
+        user,
+        swapper,
+        address,
+        h,
+        refund_privkey,
+        claim_pubkey,
+        lock_time,
+        to_spend_txid,
+        99_000,
+        new_height,
+    )
+
+    expected_utxos = len(user.list_utxos()) + 1
+    try:
+        user.bitcoin.rpc.sendrawtransaction(tx_odd)
+        assert False
+    except Exception as e:
+        if "Witness program hash mismatch" in str(e):
+            try:
+                user.bitcoin.rpc.sendrawtransaction(tx_even)
+                assert False
+            except Exception as e:
+                if "non-BIP68-final" in str(e):
+                    pass
+                else:
+                    raise
+        elif "non-BIP68-final" in str(e):
+            pass
+        else:
+            raise

--- a/swapd/proto/swap/swap.proto
+++ b/swapd/proto/swap/swap.proto
@@ -16,7 +16,7 @@ message CreateSwapRequest {
 message CreateSwapResponse {
     string address = 1;
     bytes claim_pubkey = 2;
-    uint32 lock_height = 3;
+    uint32 lock_time = 3;
     SwapParameters parameters = 4;
 }
 
@@ -39,10 +39,9 @@ message RefundSwapResponse {
 }
 
 message SwapParameters {
-    uint32 lock_time = 1;
-    uint64 max_swap_amount_sat = 2;
-    uint64 min_swap_amount_sat = 3;
-    uint64 min_utxo_amount_sat = 4;
+    uint64 max_swap_amount_sat = 1;
+    uint64 min_swap_amount_sat = 2;
+    uint64 min_utxo_amount_sat = 3;
 }
 
 message SwapParametersRequest {}

--- a/swapd/proto/swap_internal/swap_internal.proto
+++ b/swapd/proto/swap_internal/swap_internal.proto
@@ -45,7 +45,7 @@ message ListClaimableResponse {
 message ClaimableUtxo {
     string outpoint = 1;
     string swap_hash = 2;
-    uint32 lock_height = 3;
+    uint32 lock_time = 3;
     uint64 confirmation_height = 4;
     string block_hash = 5;
     int32 blocks_left = 6;

--- a/swapd/src/chain/mod.rs
+++ b/swapd/src/chain/mod.rs
@@ -9,4 +9,4 @@ pub use client::{BroadcastError, ChainClient, ChainError};
 pub use fee_estimator::{FallbackFeeEstimator, FeeEstimate, FeeEstimateError, FeeEstimator};
 pub use monitor::ChainMonitor;
 pub use repository::{AddressUtxo, ChainRepository, ChainRepositoryError, SpentTxo};
-pub use types::{BlockHeader, Utxo};
+pub use types::{BlockHeader, Txo};

--- a/swapd/src/chain/monitor.rs
+++ b/swapd/src/chain/monitor.rs
@@ -4,7 +4,7 @@ use bitcoin::{block::Bip34Error, Address, Block, Network, OutPoint};
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 use tracing::{debug, error};
 
-use crate::chain::{AddressUtxo, ChainClient, ChainRepository, SpentTxo, Utxo};
+use crate::chain::{AddressUtxo, ChainClient, ChainRepository, SpentTxo, Txo};
 
 use super::{memchain::Chain, types::BlockHeader, ChainError, ChainRepositoryError};
 
@@ -265,7 +265,7 @@ where
                     out.iter()
                         .map(|(outpoint, tx_out)| AddressUtxo {
                             address: a.clone(),
-                            utxo: Utxo {
+                            utxo: Txo {
                                 block_hash,
                                 block_height,
                                 outpoint: *outpoint,

--- a/swapd/src/chain/repository.rs
+++ b/swapd/src/chain/repository.rs
@@ -1,7 +1,7 @@
 use bitcoin::{Address, BlockHash, OutPoint, Txid};
 use thiserror::Error;
 
-use super::types::{BlockHeader, Utxo};
+use super::types::{BlockHeader, Txo};
 
 #[derive(Debug, Error)]
 pub enum ChainRepositoryError {
@@ -14,7 +14,7 @@ pub enum ChainRepositoryError {
 #[derive(Debug)]
 pub struct AddressUtxo {
     pub address: Address,
-    pub utxo: Utxo,
+    pub utxo: Txo,
 }
 
 #[derive(Debug)]
@@ -39,10 +39,14 @@ pub trait ChainRepository {
     ) -> Result<Vec<Address>, ChainRepositoryError>;
     async fn get_block_headers(&self) -> Result<Vec<BlockHeader>, ChainRepositoryError>;
     async fn get_tip(&self) -> Result<Option<BlockHeader>, ChainRepositoryError>;
+    async fn get_txos_for_address(
+        &self,
+        address: &Address,
+    ) -> Result<Vec<Txo>, ChainRepositoryError>;
     async fn get_utxos(&self) -> Result<Vec<AddressUtxo>, ChainRepositoryError>;
     async fn get_utxos_for_address(
         &self,
         address: &Address,
-    ) -> Result<Vec<Utxo>, ChainRepositoryError>;
+    ) -> Result<Vec<Txo>, ChainRepositoryError>;
     async fn undo_block(&self, hash: BlockHash) -> Result<(), ChainRepositoryError>;
 }

--- a/swapd/src/chain/types.rs
+++ b/swapd/src/chain/types.rs
@@ -1,11 +1,19 @@
 use bitcoin::{BlockHash, OutPoint, TxOut};
 
 #[derive(Clone, Debug)]
-pub struct Utxo {
+pub struct Txo {
     pub block_hash: BlockHash,
     pub block_height: u64,
     pub outpoint: OutPoint,
     pub tx_out: TxOut,
+}
+
+impl Txo {
+    pub fn confirmations(&self, current_height: u64) -> u64 {
+        current_height
+            .saturating_add(1)
+            .saturating_sub(self.block_height)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/swapd/src/claim/monitor.rs
+++ b/swapd/src/claim/monitor.rs
@@ -238,7 +238,7 @@ where
     ) -> Result<(), ClaimError> {
         let blocks_left = match claimables
             .iter()
-            .map(|r| r.swap.blocks_left(current_height))
+            .map(|r| r.blocks_left(current_height))
             .min()
         {
             Some(blocks_left) => blocks_left,
@@ -295,7 +295,7 @@ where
     ) -> Result<(), ClaimError> {
         let blocks_left = match claimables
             .iter()
-            .map(|r| r.swap.blocks_left(current_height))
+            .map(|r| r.blocks_left(current_height))
             .min()
         {
             Some(blocks_left) => blocks_left,

--- a/swapd/src/internal_server.rs
+++ b/swapd/src/internal_server.rs
@@ -259,14 +259,14 @@ where
         Ok(Response::new(ListClaimableResponse {
             claimables: claimables
                 .into_iter()
-                .map(|r| ClaimableUtxo {
-                    outpoint: r.utxo.outpoint.to_string(),
-                    swap_hash: r.swap.public.hash.to_string(),
-                    lock_height: r.swap.public.lock_height,
-                    confirmation_height: r.utxo.block_height,
-                    block_hash: r.utxo.block_hash.to_string(),
-                    blocks_left: r.swap.blocks_left(current_height),
-                    paid_with_request: r.paid_with_request,
+                .map(|c| ClaimableUtxo {
+                    outpoint: c.utxo.outpoint.to_string(),
+                    swap_hash: c.swap.public.hash.to_string(),
+                    lock_time: c.swap.public.lock_time.into(),
+                    confirmation_height: c.utxo.block_height,
+                    block_hash: c.utxo.block_hash.to_string(),
+                    blocks_left: c.blocks_left(current_height),
+                    paid_with_request: c.paid_with_request,
                 })
                 .collect(),
         }))
@@ -284,7 +284,7 @@ where
             let outpoint: OutPoint = outpoint
                 .parse()
                 .map_err(|_| Status::invalid_argument(format!("invalid outpoint {}", outpoint)))?;
-            let claimable = match all_claimables.iter().find(|r| r.utxo.outpoint == outpoint) {
+            let claimable = match all_claimables.iter().find(|c| c.utxo.outpoint == outpoint) {
                 Some(claimable) => claimable,
                 None => {
                     return Err(Status::invalid_argument(format!(
@@ -299,7 +299,7 @@ where
         let current_height = self.chain_client.get_blockheight().await?;
         let min_blocks_left = match claimables
             .iter()
-            .map(|r| r.swap.blocks_left(current_height))
+            .map(|c| c.blocks_left(current_height))
             .min()
         {
             Some(m) => m,

--- a/swapd/src/main.rs
+++ b/swapd/src/main.rs
@@ -73,7 +73,7 @@ struct Args {
     /// a script with an absolute locktime which is the current height + lock
     /// time.
     #[arg(long, default_value = "1008")]
-    pub lock_time: u32,
+    pub lock_time: u16,
 
     /// Minimum number of confirmations required before a swap is eligible for
     /// payout.

--- a/swapd/src/postgresql/claim_repository.rs
+++ b/swapd/src/postgresql/claim_repository.rs
@@ -70,6 +70,7 @@ impl claim::ClaimRepository for ClaimRepository {
         .execute(&mut *db_tx)
         .await?;
 
+        db_tx.commit().await?;
         Ok(())
     }
 
@@ -86,7 +87,7 @@ impl claim::ClaimRepository for ClaimRepository {
                ,      r.fee_per_kw
                ,      r.auto_bump
                FROM claims r
-               WHERE tx_id IN (
+               WHERE r.tx_id IN (
                    SELECT ri.claim_tx_id
                    FROM claim_inputs ri
                    WHERE ri.tx_id NOT IN (

--- a/swapd/src/postgresql/migrations/20241206_initial.up.sql
+++ b/swapd/src/postgresql/migrations/20241206_initial.up.sql
@@ -9,7 +9,7 @@ CREATE TABLE swaps (
     claim_pubkey BYTEA NOT NULL,
     claim_script BYTEA NOT NULL,
     creation_time BIGINT NOT NULL,
-    lock_height BIGINT NOT NULL,
+    lock_time INTEGER NOT NULL,
     payment_hash BYTEA NOT NULL PRIMARY KEY,
     preimage BYTEA NULL,
     refund_pubkey BYTEA NOT NULL,

--- a/swapd/src/postgresql/swap_repository.rs
+++ b/swapd/src/postgresql/swap_repository.rs
@@ -40,7 +40,7 @@ impl SwapRepository {
         let claim_pubkey: Vec<u8> = row.try_get("claim_pubkey")?;
         let claim_script: Vec<u8> = row.try_get("claim_script")?;
         let creation_time: i64 = row.try_get("creation_time")?;
-        let lock_height: i64 = row.try_get("lock_height")?;
+        let lock_time: i32 = row.try_get("lock_time")?;
         let payment_hash: Vec<u8> = row.try_get("payment_hash")?;
         let refund_pubkey: Vec<u8> = row.try_get("refund_pubkey")?;
         let refund_script: Vec<u8> = row.try_get("refund_script")?;
@@ -58,7 +58,7 @@ impl SwapRepository {
                 claim_pubkey: PublicKey::from_slice(&claim_pubkey)?,
                 claim_script: ScriptBuf::from_bytes(claim_script),
                 hash: sha256::Hash::from_slice(&payment_hash)?,
-                lock_height: lock_height as u32,
+                lock_time: lock_time as u16,
                 refund_pubkey: PublicKey::from_slice(&refund_pubkey)?,
                 refund_script: ScriptBuf::from_bytes(refund_script),
             },
@@ -91,7 +91,7 @@ impl crate::swap::SwapRepository for SwapRepository {
                ,                  claim_pubkey
                ,                  claim_script
                ,                  creation_time
-               ,                  lock_height
+               ,                  lock_time
                ,                  payment_hash
                ,                  refund_pubkey
                ,                  refund_script
@@ -102,7 +102,7 @@ impl crate::swap::SwapRepository for SwapRepository {
         .bind(swap.public.claim_pubkey.serialize())
         .bind(swap.public.claim_script.as_bytes())
         .bind(swap.creation_time.duration_since(UNIX_EPOCH)?.as_secs() as i64)
-        .bind(swap.public.lock_height as i64)
+        .bind(swap.public.lock_time as i32)
         .bind(swap.public.hash.as_byte_array().to_vec())
         .bind(swap.public.refund_pubkey.serialize())
         .bind(swap.public.refund_script.as_bytes())
@@ -485,7 +485,7 @@ fn swap_state_fields(prefix: &str) -> String {
          , {0}.claim_pubkey
          , {0}.claim_script
          , {0}.creation_time
-         , {0}.lock_height
+         , {0}.lock_time
          , {0}.payment_hash
          , {0}.preimage
          , {0}.refund_pubkey

--- a/swapd/src/swap/swap_repository.rs
+++ b/swapd/src/swap/swap_repository.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, time::SystemTime};
 use bitcoin::{hashes::sha256, secp256k1, Address, OutPoint};
 use thiserror::Error;
 
-use crate::chain::Utxo;
+use crate::chain::Txo;
 use crate::lightning::PaymentResult;
 
 use super::{swap_service::Swap, SwapState};
@@ -51,7 +51,7 @@ pub struct PaymentAttempt {
     pub creation_time: SystemTime,
     pub label: String,
     pub payment_hash: sha256::Hash,
-    pub utxos: Vec<Utxo>,
+    pub utxos: Vec<Txo>,
     pub amount_msat: u64,
     pub destination: secp256k1::PublicKey,
     pub payment_request: String,

--- a/swapd/src/whatthefee/estimator.rs
+++ b/swapd/src/whatthefee/estimator.rs
@@ -29,7 +29,7 @@ struct LastResponse {
 #[derive(Debug)]
 pub struct WhatTheFeeEstimator {
     url: Url,
-    lock_time: u32,
+    lock_time: u16,
     last_response: Arc<Mutex<Option<LastResponse>>>,
     poll_interval: Duration,
 }
@@ -41,7 +41,7 @@ pub enum WhatTheFeeError {
 }
 
 impl WhatTheFeeEstimator {
-    pub fn new(url: Url, lock_time: u32, poll_interval: Duration) -> Self {
+    pub fn new(url: Url, lock_time: u16, poll_interval: Duration) -> Self {
         Self {
             url,
             lock_time,


### PR DESCRIPTION
The absolute timelock used poses challenges. Namely the user has to get his locking transaction confirmed in a reasonable period, otherwise the swap will timeout before it has even started. In this PR, the timelock is changed to a relative timelock.

- Changed the code to use a relative timelock
- Changed the payout function to look at all outputs, not just utxos. The first confirmed output for a swap address defines the entire swap's timeout height.
- Added integration tests for unilateral refund to ensure outputs cannot be unilaterally refunded before the relative timelock expires. (I could NOT figure out which parity to use in the taproot control block. Hance that code in the test now contains a hack of trying both parities)

