### PR TITLE
ensure timely shutdown

### DIFF
--- a/swapd/src/chain/monitor.rs
+++ b/swapd/src/chain/monitor.rs
@@ -90,6 +90,7 @@ where
             }
             token2.cancel();
         });
+        tracker.close();
         tracker.wait().await;
 
         Ok(())

--- a/swapd/src/main.rs
+++ b/swapd/src/main.rs
@@ -347,7 +347,6 @@ where
     let token = CancellationToken::new();
     let signal_token = token.clone();
     let tracker = TaskTracker::new();
-
     tokio::spawn(async move {
         match signal::ctrl_c().await {
             Ok(()) => {}
@@ -484,6 +483,11 @@ where
     }
 
     info!("swapd started");
+
+    // Ensure the tracker completes when all tasks have completed.
+    tracker.close();
+
+    // Wait for all background tasks to complete.
     tracker.wait().await;
     info!("shutdown complete");
     Ok(())


### PR DESCRIPTION
When all tasks have completed, the tasktracker await doesn't return unless it's closed.
Since all tasks are spawned at the start of the program, the tracker can be closed instantly, ensuring timely shutdown as soon as all tasks have returned.