### PR TITLE
add preimage column to payment attempts query

### DIFF
--- a/itest/tests/test_swap_claim_success.py
+++ b/itest/tests/test_swap_claim_success.py
@@ -26,3 +26,12 @@ def test_swap_claim_success(node_factory, swapd_factory):
     wait_for(lambda: swapper.lightning_node.bitcoin.rpc.getmempoolinfo()["size"] == 1)
     swapper.lightning_node.bitcoin.generate_block(1)
     wait_for(lambda: len(swapper.lightning_node.list_utxos()) == expected_outputs)
+
+    swap = swapper.internal_rpc.get_swap(address)
+    assert swap.address == address
+    assert swap.creation_time > 0
+    assert swap.payment_hash == h
+    assert len(swap.outputs) == 1
+    assert len(swap.active_locks) == 0
+    assert len(swap.payment_attempts) == 1
+    assert swap.payment_attempts[0].success == True

--- a/swapd/src/postgresql/swap_repository.rs
+++ b/swapd/src/postgresql/swap_repository.rs
@@ -218,8 +218,10 @@ impl crate::swap::SwapRepository for SwapRepository {
                ,      pa.error
                ,      patx.tx_id
                ,      patx.output_index
+               ,      s.preimage
                FROM payment_attempts pa
                LEFT JOIN payment_attempt_tx_outputs patx ON pa.id = patx.payment_attempt_id
+               INNER JOIN swaps s ON pa.swap_payment_hash = s.payment_hash
                WHERE pa.swap_payment_hash = $1
                ORDER BY pa.creation_time"#,
         )


### PR DESCRIPTION
`get-swap` cli doesn't work on some swaps:

```
Error: Status { code: Internal, message: "General(ColumnNotFound(\"preimage\"))", metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Mon, 28 Apr 2025 21:15:43 GMT", "content-length": "0"} }, source: None }
```